### PR TITLE
Add overrides ability to openapi generation script

### DIFF
--- a/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
@@ -1,0 +1,206 @@
+openapi: 3.0.0
+info:
+  title: M3_ContentHostingProvisioning
+  version: 0.0.0
+  description: |
+    5GMS AS M3 Content Hosting Provisioning API
+    Copyright © 2022 British Broadcasting Corporation
+    All rights reserved.
+tags:
+  - name: M3_ContentHostingProvisioning
+    description: '5G Media Streaming: Application Server Provisioning (M3) APIs: Content Hosting Provisioning'
+externalDocs:
+  description: 'TS 26.512 V16.x.x; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m3/v1'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /content-hosting-configurations:
+    summary: "Content Hosting Configuration collection"
+    get:
+      operationId: retrieveContentHostingConfigurations
+      summary: "Retrieve a list of Content Hosting Configuration resource identifiers currently registered with the 5GMS AS"
+      responses:
+        '200':
+          # OK
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'
+
+  /content-hosting-configurations/{provisioningSessionId}:
+    summary: "Operations to manipulate a single Content Hosting Configuration resource"
+    description: "Individual Content Hosting Configuration resources in the collection are addressed by the provisioningSessionId of their parent Provisioning Session."
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+    post:
+      operationId: createContentHostingConfiguration
+      summary: 'Create and upload the Content Hosting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Content Hosting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'TS26512_M1_ContentHostingProvisioning.yaml#/components/schemas/ContentHostingConfiguration'
+      responses:
+        '201':
+          # Created
+          description: 'Content Hosting Configuration Created'
+          headers:
+            Location:
+              description: 'URL of the newly created Content Hosting Configuration (which may be redirected from the request URL).'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/Url'
+        '405':
+          # Method Not Allowed: Content Hosting Configuration resource already exists at the specified path
+          $ref: 'TS29571_CommonData.yaml#/components/responses/405'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '415':
+          # Unsupported Media Type
+          $ref: 'TS29571_CommonData.yaml#/components/responses/415'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'    
+    # (Retrieval of individual Content Hosting Configuration resources is not permitted at reference point M3.)
+    put:
+      operationId: updateContentHostingConfiguration
+      summary: 'Update (by replacement) an existing Content Hosting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Content Hosting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'TS26512_M1_ContentHostingProvisioning.yaml#/components/schemas/ContentHostingConfiguration'
+      responses:
+        '200':
+          # OK
+          description: 'Content Hosting Configuration Updated'
+        '204':
+          # No Content
+          description: 'Content Hosting Configuration Unchanged'
+        '404':
+          # Not Found
+          $ref: 'TS29571_CommonData.yaml#/components/responses/404'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '415':
+          # Unsupported Media Type
+          $ref: 'TS29571_CommonData.yaml#/components/responses/415'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default' 
+    delete:
+      operationId: destroyContentHostingConfiguration
+      summary: 'Destroy the specified Content Hosting Configuration'
+      responses:
+        '204':
+          # No Content
+          description: 'Content Hosting Configuration Destroyed'
+        '404':
+          # Not Found
+          $ref: 'TS29571_CommonData.yaml#/components/responses/404'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'
+
+  /content-hosting-configurations/{provisioningSessionId}/purge:
+    parameters:
+        - name: provisioningSessionId
+          in: path
+          required: true
+          schema:
+            $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+          description: 'The Provisioning Session identifier of an existing Content Hosting Configuration.'
+    post:
+      operationId: purgeContentHostingCache
+      summary: 'Purge the content of the cache for the specified Content Hosting Configuration'
+      requestBody:
+        description: 'The regular expression pattern for resources to purge from the cache'
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                pattern: 
+                  description: 'Keyword'
+                  type: string
+                value:
+                  description: 'The regular expression'
+                  type: string
+      responses:
+        '204':
+          # No Content
+          description: 'Content Purged'
+        '404':
+          # Not Found
+          $ref: 'TS29571_CommonData.yaml#/components/responses/404'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '415':
+          # Unsupported Media Type
+          $ref: 'TS29571_CommonData.yaml#/components/responses/415'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'

--- a/5gms/5G_APIs-overrides/M3_ServerCertificatesProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/M3_ServerCertificatesProvisioning.yaml
@@ -1,0 +1,163 @@
+openapi: 3.0.0
+info:
+  title: M3_ServerCertificatesProvisioning
+  version: 0.0.0
+  description: |
+    5GMS AS M3 Server Certificates Provisioning API
+    Copyright © 2022 British Broadcasting Corporation
+    All rights reserved.
+tags:
+  - name: M3_ServerCertificatesProvisioning
+    description: '5G Media Streaming: Application Server Provisioning (M3) APIs: Server Certificates Provisioning'
+externalDocs:
+  description: 'TS 26.512 V16.x.x; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m3/v1'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /certificates:
+    summary: "Server Certificates collection"
+    get:
+      operationId: retrieveServerCertificates
+      summary: "Retrieve a list of Server Certificate composite resource identifiers currently registered with the 5GMS AS"
+      responses:
+        '200':
+          # OK
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'
+
+  /certificates/{provisioningSessionId}+{certificateId}:
+    summary: "Operations to manipulate a single Server Certificate resource"
+    description: "Individual Server Certificate resources in the collection are addressed using a composite key since certificateId is only unique within the scope of a provisioningSessionId."
+    parameters:
+     - name: provisioningSessionId
+       in: path
+       required: true
+       schema:
+         $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+       description: 'The resource identifier of a Provisioning Session in the 5GMS AF.'
+     - name: certificateId
+       in: path
+       required: true
+       schema:
+         $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+       description: 'The resource identifier of a Server Certificate, unique within the scope of a Provisioning Session.'
+    post:
+      operationId: createServerCertificate
+      summary: "Create a new Server Certificate resource and upload an X.509 certificate bundle to be associated with it"
+      requestBody:
+        description: "As well as the public certificate itself, the PEM bundle is required to include the private key of the certificate and any intermediate CA certificates."
+        required: true
+        content:
+          application/x-pem-file:
+            schema:
+              type: string
+      responses:
+        '201':
+          # Created
+          description: "Server Certificate Created"
+          headers:
+            Location:
+              description: 'URL of the newly created Content Hosting Configuration (which may be redirected from the request URL).'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/Url'
+        '405':
+          # Method Not Allowed: Server Certificate resource already exists at the specified path
+          $ref: 'TS29571_CommonData.yaml#/components/responses/405'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '415':
+          # Unsupported Media Type
+          $ref: 'TS29571_CommonData.yaml#/components/responses/415'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'    
+    # (Retrieval of individual Server Certificate resources is not permitted at reference point M3.)
+    put:
+      operationId: updateServerCertificate
+      summary: "Update (by replacement) an existing Server Certificate resource with a new X.509 certificate bundle"
+      requestBody:
+        description: "As well as the public certificate itself, the PEM bundle is required to include the private key of the certificate and any intermediate CA certificates."
+        required: true
+        content:
+          application/x-pem-file:
+            schema:
+              type: string
+      responses:
+        '200':
+          # OK
+          description: "Server Certificate Updated"
+        '204':
+          # No Content
+          description: 'Server Certificate Unchanged'
+        '404':
+          # Not Found
+          $ref: 'TS29571_CommonData.yaml#/components/responses/404'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '415':
+          # Unsupported Media Type
+          $ref: 'TS29571_CommonData.yaml#/components/responses/415'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default' 
+    delete:
+      operationId: destroyServerCertificate
+      summary: 'Destroy an existing Server Certificate resource'
+      responses:
+        '204':
+          # No Content
+          description: 'Server Certificate Destroyed'
+        '404':
+          # Not Found
+          $ref: 'TS29571_CommonData.yaml#/components/responses/404'
+        '413':
+          # Payload too large
+          $ref: 'TS29571_CommonData.yaml#/components/responses/413'
+        '414':
+          # URI too long
+          $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'

--- a/5gms/5G_APIs-overrides/TS26512_M1_ContentHostingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/TS26512_M1_ContentHostingProvisioning.yaml
@@ -1,0 +1,292 @@
+openapi: 3.0.0
+info:
+  title: M1_ContentHostingProvisioning
+  version: 2.0.0
+  description: |
+    5GMS AF M1 Content Hosting Provisioning API
+    © 2022, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    All rights reserved.
+tags:
+  - name: M1_ContentHostingProvisioning
+    description: '5G Media Streaming: Provisioning (M1) APIs: Content Hosting Provisioning'
+externalDocs:
+  description: 'TS 26.512 V17.2.0; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m1/v2'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /provisioning-sessions/{provisioningSessionId}/content-hosting-configuration:
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+    post:
+      operationId: createContentHostingConfiguration
+      summary: 'Create (and optionally upload) the Content Hosting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Content Hosting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContentHostingConfiguration'
+      responses:
+        '201':
+          description: 'Content Hosting Configuration Created'
+          headers:
+            Location:
+              description: 'URL of the newly created Content Hosting Configuration (same as request URL).'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/Url'
+    get:
+      operationId: retrieveContentHostingConfiguration
+      summary: 'Retrieve the Content Hosting Configuration of the specified Provisioning Session'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentHostingConfiguration'
+        '404':
+          description: 'Not Found'
+    put:
+      operationId: updateContentHostingConfiguration
+      summary: 'Update the Content Hosting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Content Hosting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContentHostingConfiguration'
+      responses:
+        '204':
+          description: 'Updated Content Hosting Configuration'
+        '404':
+          description: 'Not Found'
+    patch:
+      operationId: patchContentHostingConfiguration
+      summary: 'Patch the Content Hosting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Content Hosting Configuration'
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/ContentHostingConfiguration'
+          application/json-patch+json:
+            schema:
+              $ref: '#/components/schemas/ContentHostingConfiguration'
+      responses:
+        '200':
+          description: 'Patched Content Hosting Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentHostingConfiguration'
+        '404':
+          description: 'Not Found'
+    delete:
+      operationId: destroyContentHostingConfiguration
+      summary: 'Destroy the current Content Hosting Configuration of the specified Provisioning Session'
+      responses:
+        '204':
+          description: 'Destroyed Content Hosting Configuration'
+        '404':
+          description: 'Not Found'
+          
+  /provisioning-sessions/{provisioningSessionId}/content-hosting-configuration/purge:
+    parameters:
+        - name: provisioningSessionId
+          in: path
+          required: true
+          schema:
+            $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+          description: A unique identifier of the Provisioning
+    post:
+      operationId: purgeContentHostingCache
+      summary: 'Purge the content of the cache for the Content Hosting Configuration of the specified Provisioning Session'
+      requestBody:
+        description: 'The regular expression pattern for resources to purge from the cache'
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                pattern: 
+                  description: 'Keyword'
+                  type: string
+                value:
+                  description: 'The regular expression'
+                  type: string
+      responses:
+        '200':
+          description: 'Content Purged'
+components:
+  schemas:
+    IngestConfiguration:
+      type: object
+      description: 'A configuration for content ingest.'
+      properties:
+        path:
+          type: string
+        pull:
+          type: boolean
+        protocol:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+        entryPoint:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/Url'
+    PathRewriteRule:
+      type: object
+      description: 'A rule to manipulate URL paths.'
+      required:
+        - requestPattern
+        - mappedPath
+      properties:
+        requestPattern:
+          type: string
+        mappedPath:
+          type: string
+    CachingConfiguration:
+      type: object
+      description: 'A content caching configuration.'
+      required:
+        - urlPatternFilter
+      properties:
+        urlPatternFilter:
+          type: string
+        cachingDirectives:
+          type: object
+          required:
+            - noCache
+          properties:
+            statusCodeFilters:
+              type: array
+              items:
+                type: integer
+            noCache:
+              type: boolean
+            maxAge:
+              type: integer
+              format: int32
+    DistributionConfiguration:
+      type: object
+      description: 'A content distribution configuration.'
+      required:
+        - canonicalDomainName
+        - domainNameAlias
+      properties:
+        contentPreparationTemplateId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        canonicalDomainName:
+          type: string
+        domainNameAlias:
+          type: string
+        pathRewriteRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/PathRewriteRule'
+        cachingConfigurations:
+          type: array
+          items:
+            $ref: '#/components/schemas/CachingConfiguration'
+        geoFencing:
+          type: object
+          required:
+            - locatorType
+            - locators
+          properties:
+            locatorType:
+              $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+            locators:
+              type: array
+              items: 
+                type: string
+                description: 'Format of individual locators depends on the locatorType.'
+              minItems: 1
+        urlSignature:
+          type: object
+          required:
+            - urlPattern
+            - tokenName
+            - passphraseName
+            - passphrase
+            - tokenExpiryName
+            - useIPAddress
+          properties:
+            urlPattern:
+              type: string
+            tokenName:
+              type: string
+            passphraseName:
+              type: string
+            passphrase:
+              type: string
+            tokenExpiryName:
+              type: string
+            useIPAddress:
+              type: boolean
+            ipAddressName:
+              type: string
+        certificateId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        supplementaryDistributionNetworks:
+          type: array
+          items:
+            type: object
+            properties:
+              distributionNetworkType:
+                $ref: '#/components/schemas/DistributionNetworkType'
+              distributionMode:
+                $ref: '#/components/schemas/DistributionMode'
+            required:
+              - distributionNetworkType
+              - distributionMode
+    # Schema for the resource itself
+    ContentHostingConfiguration:
+      type: object
+      description: "A representation of a Content Hosting Configuration resource."
+      required:
+        - name
+        - ingestConfiguration
+        - distributionConfigurations
+      properties:
+        name:
+          type: string
+        ingestConfiguration:
+          $ref: '#/components/schemas/IngestConfiguration'
+        distributionConfigurations:
+          type: array
+          items:
+            $ref: '#/components/schemas/DistributionConfiguration'
+
+    DistributionNetworkType:
+      description: "Type of distribution network."
+      anyOf:
+        - type: string
+          enum: [NETWORK_EMBMS]
+        - type: string
+          description: >
+            This string provides forward-compatibility with future
+            extensions to the enumeration but is not used to encode
+            content defined in the present version of this API.
+
+    DistributionMode:
+      description: "Mode of content distribution."
+      anyOf:
+        - type: string
+          enum: [MODE_EXCLUSIVE, MODE_HYBRID, MODE_DYNAMIC]
+        - type: string
+          description: >
+            This string provides forward-compatibility with future
+            extensions to the enumeration but is not used to encode
+            content defined in the present version of this API.

--- a/5gms/scripts/generate_openapi
+++ b/5gms/scripts/generate_openapi
@@ -35,13 +35,14 @@ default_destdir='openapi'
 default_openapi_gen_config=
 default_openapi_gen_version='6.0.1'
 default_yaml_dir_processor=
+default_overrides_dirs="$scriptdir/../5G_APIs-overrides"
 
 # script constants
 GIT_5G_APIS_URL='https://forge.3gpp.org/rep/all/5G_APIs.git'
 OPENAPI_GEN_URL_FORMAT='https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${OPENAPI_GEN_VERSION}/openapi-generator-cli-${OPENAPI_GEN_VERSION}.jar'
 
 # Parse command line arguments
-ARGS=`getopt -n "$scriptname" -o 'a:b:c:l:d:g:hy:' -l 'api:,branch:,generator-config:,language:,directory:,openapi-generator-version:,help,yaml-directory-processor:' -s sh -- "$@"`
+ARGS=`getopt -n "$scriptname" -o 'a:b:c:l:d:g:ho:y:' -l 'api:,branch:,generator-config:,language:,directory:,openapi-generator-version:,help,overrides-directories:,yaml-directory-processor:' -s sh -- "$@"`
 
 if [ $? -ne 0 ]; then
     print_syntax >&2
@@ -51,6 +52,7 @@ fi
 print_syntax() {
     echo "Syntax: $scriptname [-h] [-b <release-branch>] [-d <directory>]"
     echo '                    [-c <openapi-generator-config>] [-g <version>]'
+    echo '                    [-o <overrides-dir>[:<overrides-dir>...]]'
     echo '                    [-y <yaml-dir-processor>] -a <API-name>'
     echo '                    -l <language>[:<additional-properties>]'
 }
@@ -84,6 +86,10 @@ Options:
   -l LANG[:PROP[,PROP...]]  --language LANG[:PROP[,PROP...]]
                               Output language to use for OpenAPI bindings (e.g.
                               c or python).
+  -o OVERRIDES-DIRS --overrides-directories OVERRIDES-DIRS
+                              An optional list of directory paths, separated
+                              by colons, that will be searched for OpenAPI YAML
+                              files before the 5G APIs repository versions.
   -y EXE     --yaml-directory-processor EXE
                               Executable to run to process the 5G API yaml
                               directory before the generator is run. EXE will
@@ -102,6 +108,7 @@ LANGUAGE="$default_language"
 OPENAPI_GEN_CONFIG="$default_openapi_gen_config"
 OPENAPI_GEN_VERSION="$default_openapi_gen_version"
 YAML_DIR_PROCESSOR="$default_yaml_dir_processor"
+OVERRIDES_DIRS="$default_overrides_dirs"
 
 while true; do
     case "$1" in
@@ -138,6 +145,11 @@ while true; do
     -h|--help)
 	print_help
 	exit 0
+	;;
+    -o|--overrides-directories)
+	OVERRIDES_DIRS="$2"
+	shift 2
+	continue
 	;;
     -y|--yaml-directory-processor)
 	YAML_DIR_PROCESSOR="$2"
@@ -197,6 +209,22 @@ fi
 # Find JAVA
 java=`find_java`
 
+reverse_paths() {
+    old_IFS="$IFS"
+    IFS=:
+    rev=''
+    for p in $1; do
+	p=`realpath "$p"`
+	rev="${p}:$rev"
+    done
+    IFS="$old_IFS"
+    echo "${rev%:}"
+}
+
+rev_overrides_dirs=`reverse_paths "$OVERRIDES_DIRS"`
+
+echo "Overrides directories: $rev_overrides_dirs"
+
 # Create temporary directory to work in
 tmpdir=`mktemp -d --tmpdir openapi-generator.XXXXXXXX`
 trap "rm -rf '$tmpdir'" 0 1 2 3 4 5 6 7 8 10 11 12 13 14
@@ -214,6 +242,14 @@ trap "rm -rf '$tmpdir'" 0 1 2 3 4 5 6 7 8 10 11 12 13 14
         exit 1
     fi
     echo "At commit "`cd 5G_APIs; git log -g --pretty='format:%h %d' --max-count=1 HEAD`
+    # import overrides
+    (
+        IFS=:
+	for p in $rev_overrides_dirs; do
+	    echo "Copying YAML files from $p..."
+	    find "$p" -maxdepth 1 -type f -name '*.yaml' -print0 | xargs -0 -I ARGS /bin/cp -f ARGS 5G_APIs/
+	done
+    )
     # Make sure we have the APIS requested
     have_apis=1
     for API in $APIS; do


### PR DESCRIPTION
This PR adds a `-o` or `--overrides-directories` option to the `5gms/scripts/generate_openapi` script and introduces an M3 API candidate as well as updating a structure in TS 26.512 M1 ContentHostingProvisioning which causes a problem form the application function (See 5G-MAG/Standards#28).

The command line option for the script allows a colon separated list of directories, which contain overriding YAML files, to be searched before the YAML files in the 5G APIs repository. The highest priority directory is the first listed, followed by the second directory and so on. The default list of overrides directories just contains the `5gms/5G_APIs-overrides` directory in this repository.

The YAML files for a candidate M3 API have been added to the `5gms/5G_APIs-overrides` directory along with a modified version of `5G_APIs/TS26512_M1_ContentHostingProvisioning.yaml` from the 17.2.0 release of 5G_APIs. The change to the ContentHostingProvisioning YAML implements the proposed change in 5G-MAG/Standards#28.