### PR TITLE
Purge content hosting cache 422 response

### DIFF
--- a/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
@@ -195,7 +195,11 @@ paths:
           $ref: 'TS29571_CommonData.yaml#/components/responses/414'
         '422':
           # Unprocessable Entity (e.g. syntactically invalid regular expression in request body)
-          $ref: 'TS29571_CommonData.yaml#/components/responses/422'
+          description: Unprocessable Entity
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'TS29571_CommonData.yaml#/components/schemas/ProblemDetails'
         '500':
           # Internal Server Error
           $ref: 'TS29571_CommonData.yaml#/components/responses/500'

--- a/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/M3_ContentHostingProvisioning.yaml
@@ -193,6 +193,9 @@ paths:
         '414':
           # URI too long
           $ref: 'TS29571_CommonData.yaml#/components/responses/414'
+        '422':
+          # Unprocessable Entity (e.g. syntactically invalid regular expression in request body)
+          $ref: 'TS29571_CommonData.yaml#/components/responses/422'
         '500':
           # Internal Server Error
           $ref: 'TS29571_CommonData.yaml#/components/responses/500'


### PR DESCRIPTION
This is used by the 5GMS AS to indicate that there is something wrong with the request body included in the `purgeContentHostingCache` operation. For example, the regular expression provided is syntactically invalid.

In this case a `400 (Bad Request)` isn't appropriate because the HTTP request was valid. Rather, the syntax error was detected inside the application, i.e. above the Layer 7 application protocol.