### PR TITLE
Bug fix: Add missing metricsReportingConfigurationId

### DIFF
--- a/5gms/5G_APIs-overrides/TS26512_M5_ServiceAccessInformation.yaml
+++ b/5gms/5G_APIs-overrides/TS26512_M5_ServiceAccessInformation.yaml
@@ -1,16 +1,16 @@
 openapi: 3.0.0
 info:
   title: M5_ServiceAccessInformation
-  version: 2.4.0
+  version: 2.4.1-reftools1
   description: |
     5GMS AF M5 Service Access Information API
-    © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    © 2024, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
     All rights reserved.
 tags:
   - name: M5_ServiceAccessInformation
     description: '5G Media Streaming: Media Session Handling (M5) APIs: Service Access Information'
 externalDocs:
-  description: 'TS 26.512 V17.7.0; 5G Media Streaming (5GMS); Protocols'
+  description: 'TS 26.512 V17.8.0; 5G Media Streaming (5GMS); Protocols'
   url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
 servers:
   - url: '{apiRoot}/3gpp-m5/v2'
@@ -136,6 +136,7 @@ components:
           items:
             type: object
             required:
+            - metricsReportingConfigurationId
             - serverAddresses
             - scheme
             - samplePercentage
@@ -143,8 +144,15 @@ components:
             - samplingPeriod
             - metrics
             properties:
+              metricsReportingConfigurationId:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
               serverAddresses:
                 $ref: '#/components/schemas/ServerAddresses'
+              sliceScope:
+                type: array
+                items:
+                  $ref: 'TS29571_CommonData.yaml#/components/schemas/Snssai'
+                minItems: 1
               scheme:
                 $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
               dataNetworkName:

--- a/5gms/5G_APIs-overrides/TS26512_M5_ServiceAccessInformation.yaml
+++ b/5gms/5G_APIs-overrides/TS26512_M5_ServiceAccessInformation.yaml
@@ -1,0 +1,214 @@
+openapi: 3.0.0
+info:
+  title: M5_ServiceAccessInformation
+  version: 2.4.0
+  description: |
+    5GMS AF M5 Service Access Information API
+    © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    All rights reserved.
+tags:
+  - name: M5_ServiceAccessInformation
+    description: '5G Media Streaming: Media Session Handling (M5) APIs: Service Access Information'
+externalDocs:
+  description: 'TS 26.512 V17.7.0; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m5/v2'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /service-access-information/{provisioningSessionId}:
+    parameters:
+      - name: provisioningSessionId
+        description: 'The resource identifier of an existing Provisioning Session.'
+        in: path
+        required: true
+        schema:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+    get:
+      operationId: retrieveServiceAccessInformation
+      summary: 'Retrieve the Service Access Information resource'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/ServiceAccessInformationResource'
+        '404':
+          description: 'Not Found'
+components:
+  schemas:
+    M5MediaEntryPoint:
+      description: "A typed entry point for downlink or uplink media streaming."
+      type: object
+      required:
+        - locator
+        - contentType
+      properties:
+        locator:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+        contentType:
+          type: string
+        profiles:
+          type: array
+          items:
+            $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+          minItems: 1
+
+    ServerAddresses:
+      description: "A set of application endpoint addresses."
+      type: array
+      items:
+        $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+      minItems: 1
+
+    ServiceAccessInformationResource:
+      description: "A representation of a Service Access Information resource."
+      type: object
+      required:
+      - provisioningSessionId
+      - provisioningSessionType
+      properties:
+        provisioningSessionId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        provisioningSessionType:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ProvisioningSessionType'
+        streamingAccess:
+          type: object
+          properties:
+            entryPoints:
+              type: array
+              items:
+                $ref: '#/components/schemas/M5MediaEntryPoint'
+            eMBMSServiceAnnouncementLocator:
+              $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+        clientConsumptionReportingConfiguration:
+          type: object
+          required:
+            - serverAddresses
+            - locationReporting
+            - accessReporting
+            - samplePercentage
+          properties:
+            reportingInterval:
+              $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+            serverAddresses:
+              $ref: '#/components/schemas/ServerAddresses'
+            locationReporting:
+              type: boolean
+            accessReporting:
+              type: boolean
+            samplePercentage:
+              $ref: 'TS26512_CommonData.yaml#/components/schemas/Percentage'
+        dynamicPolicyInvocationConfiguration:
+          type: object
+          required:
+            - serverAddresses
+            - policyTemplateBindings
+            - sdfMethods
+          properties: 
+            serverAddresses:
+              $ref: '#/components/schemas/ServerAddresses'
+            policyTemplateBindings:
+              type: array
+              minItems: 1
+              items: 
+                type: object
+                required:
+                  - externalReference
+                  - policyTemplateId
+                properties: 
+                  externalReference:
+                    type: string
+                  policyTemplateId:
+                    $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+            sdfMethods:
+              type: array
+              items:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/SdfMethod'
+              minItems: 0
+        clientMetricsReportingConfigurations:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+            - serverAddresses
+            - scheme
+            - samplePercentage
+            - urlFilters
+            - samplingPeriod
+            - metrics
+            properties:
+              serverAddresses:
+                $ref: '#/components/schemas/ServerAddresses'
+              scheme:
+                $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+              dataNetworkName:
+                $ref: 'TS29571_CommonData.yaml#/components/schemas/Dnn'
+              reportingInterval:
+                $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+              samplePercentage:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/Percentage'
+              urlFilters:
+                type: array
+                items:
+                  type: string
+                minItems: 0
+              samplingPeriod:
+                $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+              metrics:
+                type: array
+                items:
+                  type: string
+        networkAssistanceConfiguration:
+          type: object
+          required: 
+            - serverAddresses
+          properties:
+            serverAddresses:
+              $ref: '#/components/schemas/ServerAddresses'
+        clientEdgeResourcesConfiguration:
+          type: object
+          required:
+            - easDiscoveryTemplate
+          properties:
+            eligibilityCriteria:
+              $ref: 'TS26512_CommonData.yaml#/components/schemas/EdgeProcessingEligibilityCriteria'
+            easDiscoveryTemplate:
+              $ref: '#/components/schemas/EASDiscoveryTemplate'
+            easRelocationRequirements:
+              $ref: '#/components/schemas/M5EASRelocationRequirements'
+
+    M5EASRelocationRequirements:
+      description: 'Relocation requirements of an EAS.'
+      type: object
+      required:
+        - tolerance
+      properties:
+        tolerance:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/EASRelocationTolerance'
+        maxInterruptionDuration:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/UintegerRm'
+
+    EASDiscoveryTemplate:
+      description: 'A template for discovering an EAS instance .'
+      type: object
+      properties:
+        easId:
+          type: string
+        easType:
+          type: string
+        easProviderIds:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        serviceFeatures:
+          type: array
+          items:
+            type: string
+          minItems: 1


### PR DESCRIPTION
This PR adds a mandatory `ServiceAccessInformationResource.clientMetricsReportingConfigurations.metricsReportingConfigurationId` field to the M5 *ServiceAccessInformation* API as an override to the TSG102-Rel17 branch of the 3GPP 5G_APIs.

This also pulls in the proposed TSG103 change to add an optional `sliceScope` field.

Part of fix for 5G-MAG/Standards#119, will need to update 5GMS AF to populate the new metricsReportingConfigurationId field once this is merged.
