### PR TITLE
Bug-fix: Add range checking for parameters in MetricsReportingConfiguration

### DIFF
--- a/5gms/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.0
+info:
+  title: M1_MetricsReportingProvisioning
+  version: 2.1.0
+  description: |
+    5GMS AF M1 Metrics Reporting Provisioning API
+    © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    All rights reserved.
+tags:
+  - name: M1_MetricsReportingProvisioning
+    description: '5G Media Streaming: Provisioning (M1) APIs: Metrics Reporting Provisioning'
+externalDocs:
+  description: 'TS 26.512 V17.6.0; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m1/v2'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /provisioning-sessions/{provisioningSessionId}/metrics-reporting-configurations:
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+    post:
+      operationId: activateMetricsReporting
+      summary: 'Activate the Metrics reporting procedure for the specified Provisioning Session by providing the Metrics Reporting Configuration'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '201':
+          description: 'Metrics Reporting Configuration Created'
+          headers:
+            Location:
+              description: 'URL of the newly created Metrics Reporting Configuration (same as request URL).'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+  /provisioning-sessions/{provisioningSessionId}/metrics-reporting-configurations/{metricsReportingConfigurationId}:
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+      - name: metricsReportingConfigurationId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of a Metrics Reporting Configuration.'
+    get:
+      operationId: retrieveMetricsReportingConfiguration
+      summary: 'Retrieve the specified Metrics Reporting Configuration of the specified Provisioning Session'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsReportingConfiguration'
+    put:
+      operationId: updateMetricsReportingConfiguration
+      summary: 'Update the specified Metrics Reporting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '204':
+          description: 'Updated Metrics Reporting Configuration'
+        '404':
+          description: 'Not Found'
+    patch:
+      operationId: patchMetricsReportingConfiguration
+      summary: 'Patch the specified Metrics Reporting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+          application/json-patch+json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '200':
+          description: 'Patched Metrics Reporting Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsReportingConfiguration'
+        '404':
+          description: 'Not Found'
+    delete:
+      operationId: destroyMetricsReportingConfiguration
+      summary: 'Destroy the specified Metrics Reporting Configuration of the specified Provisioning Session'
+      responses:
+        '204':
+          description: 'Destroyed Metrics Reporting Configuration'
+        '404':
+          description: 'Not Found'    
+components:
+  schemas:
+    MetricsReportingConfiguration:
+      type: object
+      description: "A representation of a Metrics Reporting Configuration resource."
+      required:
+        - metricsReportingConfigurationId
+        - samplingPeriod
+      properties:
+        metricsReportingConfigurationId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        scheme:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+        dataNetworkName:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/Dnn'
+        reportingInterval:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+        samplePercentage:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/Percentage'
+        urlFilters:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        samplingPeriod:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+        metrics:
+          type: array
+          items:
+            type: string
+          minItems: 1

--- a/5gms/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
+++ b/5gms/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: M1_MetricsReportingProvisioning
-  version: 2.1.0
+  version: 2.1.0-reftools1
   description: |
     5GMS AF M1 Metrics Reporting Provisioning API
     © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
@@ -125,13 +125,18 @@ components:
         - samplingPeriod
       properties:
         metricsReportingConfigurationId:
-          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+          readOnly: true
+          allOf:
+            - $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
         scheme:
           $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
         dataNetworkName:
           $ref: 'TS29571_CommonData.yaml#/components/schemas/Dnn'
         reportingInterval:
-          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+          minimum: 0
+          exclusiveMinimum: true
+          allOf:
+            - $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
         samplePercentage:
           $ref: 'TS26512_CommonData.yaml#/components/schemas/Percentage'
         urlFilters:
@@ -140,7 +145,10 @@ components:
             type: string
           minItems: 1
         samplingPeriod:
-          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+          minimum: 0
+          exclusiveMinimum: true
+          allOf:
+            - $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
         metrics:
           type: array
           items:


### PR DESCRIPTION
This is the *rt-common-shared* counterpart to 5G-MAG/rt-5gms-application-function#148

This moves `TS26512_M1_MetricsReportingProvisioning.yaml` from *rt-5gms-application-function* back into this repository and adds integer bounds for the `reportingInterval` and `samplingPeriod` properties.

See commit [1210229](https://github.com/5G-MAG/rt-common-shared/commit/12102299bb4775f9a8d10225d5e20c2a96422b9c) for differences from the TS 26.512 v17.7.0 baseline.