### PR TITLE
Fix URLs in the README.md

### DIFF
--- a/simple-express-server/README.md
+++ b/simple-express-server/README.md
@@ -9,13 +9,13 @@ A simple HTTP server based on express.js that can be used to statically host fil
 ### Clone the repository
 
 ````
-git clone --recurse-submodules https://github.com/5G-MAG/rt-mbms-examples
+git clone --recurse-submodules https://github.com/5G-MAG/rt-common-shared
 ```` 
 
 ### Install dependencies
 
 ````
-cd rt-mbms-examples/simple-express-server
+cd rt-common-shared/simple-express-server
 npm install
 ````
 


### PR DESCRIPTION
This addresses #42 . Fixes wrong links in the Readme file of the simple-express-server