### PR TITLE
C++ OpenAPI templates: Fix AnyType compare operator constness

### DIFF
--- a/open5gs-tools/openapi-generator-templates/cpp-restbed-server/AnyType.hh
+++ b/open5gs-tools/openapi-generator-templates/cpp-restbed-server/AnyType.hh
@@ -54,7 +54,7 @@ public:
         return *this;
     };
 
-    bool operator==(const AnyType &other) {
+    bool operator==(const AnyType &other) const {
         if (!m_val && !other.m_val) return true;
         if (!m_val) return false;
         if (!other.m_val) return false;


### PR DESCRIPTION
This PR fixes the constness of the `operator==()` in the template `AnyType` class.