### PR TITLE
C++ OpenAPI Templates: Add ByteArray type as complex leaf node type in applyJSONPatch()

### DIFF
--- a/open5gs-tools/openapi-generator-templates/cpp-restbed-server/model-source-object-patch-leaf.mustache
+++ b/open5gs-tools/openapi-generator-templates/cpp-restbed-server/model-source-object-patch-leaf.mustache
@@ -38,7 +38,9 @@
                    throw ModelException(std::string("Runtime Error: JSON Patch operation ") + op + " not implemented for {{baseName}}", "{{classname}}", "{{baseName}}", ProblemCause::SYSTEM_FAILURE);
 {{/isUri}}{{#isEmail}}
                    throw ModelException(std::string("Runtime Error: JSON Patch operation ") + op + " not implemented for {{baseName}}", "{{classname}}", "{{baseName}}", ProblemCause::SYSTEM_FAILURE);
-{{/isEmail}}{{^isString}}{{^isDate}}{{^isDateTime}}{{^isUuid}}{{^isUri}}{{^isEmail}}
+{{/isEmail}}{{#isByteArray}}
+                  throw ModelException(std::string("Runtime Error: JSON Patch operation ") + op + " not implemented for {{baseName}}", "{{classname}}", "{{baseName}}", ProblemCause::SYSTEM_FAILURE);
+{{/isByteArray}}{{^isString}}{{^isDate}}{{^isDateTime}}{{^isUuid}}{{^isUri}}{{^isEmail}}{{^isByteArray}}
                    CJson new_patch(json);
                    new_patch.set("path", CJson::newString(path_rest));
                    try {
@@ -60,5 +62,5 @@
                        }
                        throw ModelException(ex.what(), "{{classname}}", param.str(), ex.cause);
                    }
-{{/isEmail}}{{/isUri}}{{/isUuid}}{{/isDateTime}}{{/isDate}}{{/isString}}{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}
+{{/isByteArray}}{{/isEmail}}{{/isUri}}{{/isUuid}}{{/isDateTime}}{{/isDate}}{{/isString}}{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}
                }

--- a/open5gs-tools/openapi-generator-templates/cpp-restbed-server/model-source-object-patch-recurse.mustache
+++ b/open5gs-tools/openapi-generator-templates/cpp-restbed-server/model-source-object-patch-recurse.mustache
@@ -182,7 +182,9 @@
                     throw ModelException("Runtime Error: JSON Patch path extends beyond leaf field", "{{classname}}", "path", ProblemCause::INVALID_MSG_FORMAT);
 {{/isUri}}{{#isEmail}}
                     throw ModelException("Runtime Error: JSON Patch path extends beyond leaf field", "{{classname}}", "path", ProblemCause::INVALID_MSG_FORMAT);
-{{/isEmail}}{{^isString}}{{^isDate}}{{^isDateTime}}{{^isUuid}}{{^isUri}}{{^isEmail}}{{<is-optional}}{{$yes}}
+{{/isEmail}}{{#isByteArray}}
+                    throw ModelException("Runtime Error: JSON Patch path extends beyond leaf field", "{{classname}}", "path", ProblemCause::INVALID_MSG_FORMAT);
+{{/isByteArray}}{{^isString}}{{^isDate}}{{^isDateTime}}{{^isUuid}}{{^isUri}}{{^isEmail}}{{^isByteArray}}{{<is-optional}}{{$yes}}
                     if (patched_obj) {
 {{/yes}}{{/is-optional}}
                       CJson new_patch(json);
@@ -206,5 +208,5 @@
                     }
 {{/yes}}{{/is-optional}}
                     return;
-{{/isEmail}}{{/isUri}}{{/isUuid}}{{/isDateTime}}{{/isDate}}{{/isString}}{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}
+{{/isByteArray}}{{/isEmail}}{{/isUri}}{{/isUuid}}{{/isDateTime}}{{/isDate}}{{/isString}}{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}
                   }


### PR DESCRIPTION
The `applyJSONPatch()` method in the C++ templates does not recognise the ByteArray complex type as a leaf node type and can therefore create code which cannot be compiled when a ByteArray type field is present in the OpenAPI YAML.

This PR fixes this by adding the ByteArray type to the list of leaf node types in the templates.