### PR TITLE
Fix URI regex and validate baseURL as AbsoluteUrl

### DIFF
--- a/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
+++ b/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
@@ -19,7 +19,7 @@
 #define _OPENAPI_URI_RE_PATH_NOSCHEME _OPENAPI_URI_RE_SEGMENT_NZ_NC "(?:/" _OPENAPI_URI_RE_SEGMENT ")*"
 #define _OPENAPI_URI_RE_PATH_ABSOLUTE "/(?:" _OPENAPI_URI_RE_PATH_ROOTLESS ")?"
 #define _OPENAPI_URI_RE_PATH_ABEMPTY "(?:/" _OPENAPI_URI_RE_SEGMENT ")*"
-#define _OPENAPI_URI_RE_PATH = "(?:" _OPENAPI_URI_RE_PATH_ABEMPTY "|" _OPENAPI_URI_RE_PATH_ABSOLUTE "|" _OPENAPI_URI_RE_PATH_NOSCHEME "|" _OPENAPI_URI_RE_PATH_ROOTLESS ")"
+#define _OPENAPI_URI_RE_PATH "(?:" _OPENAPI_URI_RE_PATH_ABEMPTY "|" _OPENAPI_URI_RE_PATH_ABSOLUTE "|" _OPENAPI_URI_RE_PATH_NOSCHEME "|" _OPENAPI_URI_RE_PATH_ROOTLESS ")"
 #define _OPENAPI_URI_RE_DEC_OCTET "(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])"
 #define _OPENAPI_URI_RE_REG_NAME "(?:[-a-zA-Z0-9._~!$&'()*+,;=]|" _OPENAPI_URI_RE_PCT_ENCODED ")*"
 #define _OPENAPI_URI_RE_IPV4_ADDRESS _OPENAPI_URI_RE_DEC_OCTET "(?:\\." _OPENAPI_URI_RE_DEC_OCTET "){3}"
@@ -36,7 +36,9 @@
 #define _OPENAPI_URI_RE_RELATIVE_REF _OPENAPI_URI_RE_RELATIVE_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?(?:#" _OPENAPI_URI_RE_FRAGMENT ")?"
 #define _OPENAPI_URI_RE_HIER_PART "(?://" _OPENAPI_URI_RE_AUTHORITY _OPENAPI_URI_RE_PATH_ABEMPTY "|" _OPENAPI_URI_RE_PATH_ABSOLUTE "|" _OPENAPI_URI_RE_PATH_ROOTLESS "|)"
 #define _OPENAPI_URI_RE_ABSOLUTE_URI _OPENAPI_URI_RE_SCHEME ":" _OPENAPI_URI_RE_HIER_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?"
-#define _OPENAPI_URI_REGEX "^" _OPENAPI_URI_RE_SCHEME ":" _OPENAPI_URI_RE_HIER_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?(?:#" _OPENAPI_URI_RE_FRAGMENT ")?"
+#define _OPENAPI_URI_REGEX "^" _OPENAPI_URI_RE_SCHEME ":" _OPENAPI_URI_RE_HIER_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?(?:#" _OPENAPI_URI_RE_FRAGMENT ")?$"
+
+#define _OPENAPI_ABSOLUTE_URL_REGEX "^https?://(?:[^/?#[:space:]]+)(?:/[^?#[:space:]]*)?(?:[?][^#[:space:]]*)?$"
 
 #define _OPENAPI_UUID_REGEX "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 
@@ -1156,7 +1158,11 @@ end:
 
     static OpenAPI_regex_t *{{{name}}}_regex = NULL;
     if (!{{{name}}}_regex) {
-        {{{name}}}_regex = OpenAPI_regex_register_named("uri",_OPENAPI_URI_REGEX);
+        if (!strcmp("{{{baseName}}}", "baseURL")) {
+            {{{name}}}_regex = OpenAPI_regex_register_named("absolute-url", _OPENAPI_ABSOLUTE_URL_REGEX);
+        } else {
+            {{{name}}}_regex = OpenAPI_regex_register_named("uri", _OPENAPI_URI_REGEX);
+        }
         if (!{{{name}}}_regex) {
             ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Failed to compile uri regex");
             if ({{classname}}_parse_err) *{{classname}}_parse_err = "Failed to compile the uri validation regex for \"{{{baseName}}}\"";

--- a/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
+++ b/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
@@ -1156,8 +1156,7 @@ end:
 
     static OpenAPI_regex_t *{{{name}}}_regex = NULL;
     if (!{{{name}}}_regex) {
-            {{{name}}}_regex = OpenAPI_regex_register_named("uri", _OPENAPI_URI_REGEX);
-        }
+        {{{name}}}_regex = OpenAPI_regex_register_named("uri",_OPENAPI_URI_REGEX);
         if (!{{{name}}}_regex) {
             ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Failed to compile uri regex");
             if ({{classname}}_parse_err) *{{classname}}_parse_err = "Failed to compile the uri validation regex for \"{{{baseName}}}\"";

--- a/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
+++ b/open5gs-tools/openapi-generator-templates/c/model-body-object-defs.mustache
@@ -38,8 +38,6 @@
 #define _OPENAPI_URI_RE_ABSOLUTE_URI _OPENAPI_URI_RE_SCHEME ":" _OPENAPI_URI_RE_HIER_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?"
 #define _OPENAPI_URI_REGEX "^" _OPENAPI_URI_RE_SCHEME ":" _OPENAPI_URI_RE_HIER_PART "(?:\\?" _OPENAPI_URI_RE_QUERY ")?(?:#" _OPENAPI_URI_RE_FRAGMENT ")?$"
 
-#define _OPENAPI_ABSOLUTE_URL_REGEX "^https?://(?:[^/?#[:space:]]+)(?:/[^?#[:space:]]*)?(?:[?][^#[:space:]]*)?$"
-
 #define _OPENAPI_UUID_REGEX "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 
 {{classname}}_t *{{classname}}_create(
@@ -1158,9 +1156,6 @@ end:
 
     static OpenAPI_regex_t *{{{name}}}_regex = NULL;
     if (!{{{name}}}_regex) {
-        if (!strcmp("{{{baseName}}}", "baseURL")) {
-            {{{name}}}_regex = OpenAPI_regex_register_named("absolute-url", _OPENAPI_ABSOLUTE_URL_REGEX);
-        } else {
             {{{name}}}_regex = OpenAPI_regex_register_named("uri", _OPENAPI_URI_REGEX);
         }
         if (!{{{name}}}_regex) {


### PR DESCRIPTION
This PR Fixes the validation bug of the baseURL:

`baseURL` uses `AbsoluteUrl` data type according to `3GPP TS 26.512 V17.10.0 (2025-01)`

in [TS26512_CommonData.yaml](https://forge.3gpp.org/rep/all/5G_APIs/-/blob/REL-17/TS26512_CommonData.yaml) is "AbsoluteUrl" defined as:

```
    AbsoluteUrl:
      type: string
      format: uri
      description: 'Absolute Uniform Resource Locator, conforming with the "absolute-URI" production specified in IETF RFC 3986, section 4.3 in which the scheme part is "http" or "https". Note that the "query" suffix is permitted by this production but the "fragment" suffix is not.'
```

IETF RFC 3986, section 4.3: 

> ## [4.3](https://www.rfc-editor.org/info/rfc3986/#section-4.3).  Absolute URI
> 
> Some protocol elements allow only the absolute form of a URI without a fragment identifier.  For example, defining a base URI for later use by relative references calls for an absolute-URI syntax rule that does not allow a fragment.
> 
>       absolute-URI  = scheme ":" hier-part [ "?" query ]
> 
> URI scheme specifications must define their own syntax so that all strings matching their scheme-specific syntax will also match the <absolute-URI> grammar.  Scheme specifications will not define fragment identifier syntax or usage, regardless of its applicability to resources identifiable via that scheme, as fragment identification is orthogonal to scheme definition.  However, scheme specifications are encouraged to include a wide range of examples, including examples that show use of the scheme's URIs with fragment identifiers when such usage is appropriate.

The existing generic URI regex is too broad for baseURL, because it accepts valid non-HTTP(S) URIs such as:
`mailto:someone@example.com`

As far as I understand it, the [libmpd++ regex](https://github.com/5G-MAG/rt-5gms-application-function/pull/196#discussion_r3304085179) and the regex from the template that is currently used is still too broad for BaseURL. it allows schemes other than http and https.